### PR TITLE
[modify]이미지 업로드 함수 파일 분리

### DIFF
--- a/nakwon_online_shoppingmall/android/gradle/wrapper/gradle-wrapper.properties
+++ b/nakwon_online_shoppingmall/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/nakwon_online_shoppingmall/lib/pages/regist/widgets/jaket_photo_button.dart
+++ b/nakwon_online_shoppingmall/lib/pages/regist/widgets/jaket_photo_button.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'dart:io';
+
+class JaketPhotoButton extends StatefulWidget {
+  const JaketPhotoButton({
+    super.key,
+    required this.image,
+  });
+
+  final XFile? image;
+
+  @override
+  State<JaketPhotoButton> createState() => _JaketPhotoButtonState();
+}
+
+class _JaketPhotoButtonState extends State<JaketPhotoButton> {
+  Future<void> getImagePickerData(XFile? image) async {
+    final ImagePicker picker = ImagePicker();
+    final XFile? pickedImage =
+        await picker.pickImage(source: ImageSource.gallery);
+    if (pickedImage != null) {
+      setState(() {
+        image = pickedImage;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.image != null
+        ? GestureDetector(
+            onTap: () {
+              getImagePickerData(widget.image);
+            },
+            child: SizedBox(
+              width: 220,
+              height: 240,
+              child: FittedBox(
+                  fit: BoxFit.fill,
+                  child: Image.file(File(widget.image!.path))),
+            ),
+          )
+        : GestureDetector(
+            onTap: () {
+              getImagePickerData(widget.image);
+            },
+            child: Container(
+              width: 220,
+              height: 240,
+              color: Colors.grey[300],
+            ),
+          );
+  }
+}


### PR DESCRIPTION
이미지를 업로드하는 함수를 기존의 regist_page.dart에서 각각 개별 파일로 분리했습니다.
- jaket_photo_button.dart : 누르면 이미지를 업로드하고, 자켓 이미지를 보여주는 중앙 박스 부분입니다.
- background_photo.dart : 자켓 이미지 뒤에 배경으로 흐릿하게 깔리는 꾸미기 영역입니다. 아직 흐리게 이펙트는 적용하지 않았습니다.